### PR TITLE
Fixed dependency and plugin compatibility for onos-2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,17 @@ ONOS is a new SDN network operating system designed for high availability,
 performance, scale-out.
 
 ### Versions
-ONOS 2.7.0
-Apache Maven 3.6.3
-Java version: 11.0.20, vendor: Ubuntu, runtime: /usr/lib/jvm/java-11-openjdk-amd64
+ONOS 2.7.0 <br/>
+Apache Maven 3.6.3<br/>
+Java version: 11.0.20, vendor: Ubuntu, runtime: /usr/lib/jvm/java-11-openjdk-amd64<br/>
 
-You can find the main project repository here:
-https://github.com/opennetworkinglab/onos
+
+
 
 ### Where can I learn more about ONOS?
 Checkout out our [website](http://www.onosproject.org) and our
 [tools](http://www.onosproject.org/software/#tools)
+<br/><br/>
+You can find the main project repository here:<br/>
+https://github.com/opennetworkinglab/onos
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,15 @@ This repository contains sample and testing applications for ONOS.
 ONOS is a new SDN network operating system designed for high availability,
 performance, scale-out.
 
+### Versions
+ONOS 2.7.0
+Apache Maven 3.6.3
+Java version: 11.0.20, vendor: Ubuntu, runtime: /usr/lib/jvm/java-11-openjdk-amd64
+
 You can find the main project repository here:
 https://github.com/opennetworkinglab/onos
 
 ### Where can I learn more about ONOS?
 Checkout out our [website](http://www.onosproject.org) and our
 [tools](http://www.onosproject.org/software/#tools)
+

--- a/carrierethernet/pom.xml
+++ b/carrierethernet/pom.xml
@@ -193,10 +193,11 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+          <!-- Updated apache.felix version from 1.21.0 to 1.22.0 for onos 2.7.0 compatibility-->
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-scr-plugin</artifactId>
-                <version>1.21.0</version>
+                <version>1.22.0</version>
                 <executions>
                     <execution>
                         <id>generate-scr-srcdescriptor</id>

--- a/ipfix/pom.xml
+++ b/ipfix/pom.xml
@@ -142,7 +142,8 @@
                     </execution>
                 </executions>
               <!-- Added plugin for onos 2.7.0 compatibility-->
-              <plugin>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
@@ -150,8 +151,6 @@
                     <reuseForks>true</reuseForks>
                     <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
                 </configuration>
-              </plugin>
-
             </plugin>
         </plugins>
     </build>

--- a/ipfix/pom.xml
+++ b/ipfix/pom.xml
@@ -141,6 +141,17 @@
                         </goals>
                     </execution>
                 </executions>
+              <!-- Added plugin for onos 2.7.0 compatibility-->
+              <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>3</forkCount>
+                    <reuseForks>true</reuseForks>
+                    <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+                </configuration>
+              </plugin>
+
             </plugin>
         </plugins>
     </build>

--- a/mef-nrp-api/pom.xml
+++ b/mef-nrp-api/pom.xml
@@ -184,6 +184,29 @@
             <artifactId>jersey-media-multipart</artifactId>
         </dependency>
 
+        <!-- New dependencies for onos 2.7.0 compatibility -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.3</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+
+
         <!-- End of extra dependencies due to MEF NRP API code -->
 
     </dependencies>

--- a/mef-sca-api/pom.xml
+++ b/mef-sca-api/pom.xml
@@ -184,6 +184,28 @@
             <artifactId>jersey-media-multipart</artifactId>
         </dependency>
 
+        <!-- New dependencies for onos 2.7.0 compatibility -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.3</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+
         <!-- End of extra dependencies due to MEF SCA API code -->
 
     </dependencies>

--- a/pppoe/pom.xml
+++ b/pppoe/pom.xml
@@ -83,6 +83,16 @@
                 <groupId>org.onosproject</groupId>
                 <artifactId>onos-maven-plugin</artifactId>
             </plugin>
+          <!--Added plugin for onos 2.7.0 compatibility-->
+            <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+                 <artifactId>maven-surefire-plugin</artifactId>
+                 <configuration>
+                       <forkCount>3</forkCount>
+                       <reuseForks>true</reuseForks>
+                       <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+                 </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/sdx-l2/pom.xml
+++ b/sdx-l2/pom.xml
@@ -194,6 +194,16 @@
                 </execution>
             </executions>
         </plugin>
+       <!--Added a plugin for onos 2.7.0 compatibility-->
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+                <forkCount>3</forkCount>
+                <reuseForks>true</reuseForks>
+                <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+            </configuration>
+        </plugin>
     </plugins>
 </build>
 

--- a/sdx-l3/pom.xml
+++ b/sdx-l3/pom.xml
@@ -114,6 +114,16 @@
                 <groupId>org.onosproject</groupId>
                 <artifactId>onos-maven-plugin</artifactId>
             </plugin>
+          <!--Added a plugin for onos 2.7.0 compatibility-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>3</forkCount>
+                    <reuseForks>true</reuseForks>
+                    <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
onos-app-samples do not work with the newest version of onos (v.2.7.0) so i have updated some plugin versions and added the new dependencies.